### PR TITLE
Add explicit source-commenting standards to template docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,15 @@ If you introduce a new root-level `ALLCAPS.md` file, treat it as a new control d
 - Update `PLANS.md` if ExecPlans are expected to read, update, or validate that file.
 - State what kinds of code or product changes must keep the new file in sync.
 
+
+## Code Commenting Requirements
+When editing or adding source code, comments are required so reviewers can understand intent without reconstructing logic from scratch.
+
+- Add a file-header comment at the top of every source file summarizing the file purpose, key classes/functions, and how the file fits into the project.
+- Add a short comment above every non-trivial function describing what it does; for complex functions, include a brief step-by-step outline of the control flow.
+- Add inline comments for unclear variable names, non-obvious assumptions, and hard-coded constants so future contributors understand why values exist.
+- Avoid redundant comments that only restate syntax; comments should explain intent and reasoning.
+
 ## Project Structure & Module Organization
 This repository is intentionally minimal at the moment. Keep runtime code in `src/`, mirror tests in `tests/`, keep static assets in `assets/`, and leave long-lived documentation in the repository root.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -56,6 +56,10 @@ If a small or medium feature lands without an ExecPlan, this section should usua
 
 `Core`: The template instructs contributors to save substantial-work plans under `plans/` with two-digit ordered filename prefixes, such as `00-add-feature-x.md` and `01-security-overhaul.md`. The ordering rule keeps multiple active or historical ExecPlans easy to scan without relying on chat history or issue context.
 
+### Commented Source Expectations
+
+`Core`: Contributor guidance requires source files to include file-level purpose comments, non-trivial functions to include summary comments, and complex or assumption-heavy logic to include inline explanatory comments. This expectation is part of the current agent-assisted workflow and review standard for template-derived repositories.
+
 ## 4. Core Workflows
 
 Describe the end-to-end workflows that currently define the product.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Once you introduce a real toolchain, replace this section with the canonical com
 
 - Keep runtime code in `src/`.
 - Mirror tests under `tests/`.
+- Add explanatory comments to source files: file-header purpose comments, non-trivial function summaries, and inline notes for non-obvious logic or constants.
 - Keep static assets in `assets/` when needed.
 - Keep `PRODUCT.md` in sync with current user-visible behavior and scope.
 - Keep `ROADMAP.md` in sync with durable product direction and priorities.


### PR DESCRIPTION
### Motivation
- A reviewer flagged unclear code and hard-coded assumptions and asked for an explicit commenting standard to improve reviewability and agent-assisted contributions.
- The template must surface this expectation in the repository control documents so template-derived projects inherit the rule by default.

### Description
- Add a new **Code Commenting Requirements** section to `AGENTS.md` that mandates a file-header purpose comment, summary comments for non-trivial functions, and inline notes for non-obvious logic and hard-coded constants.
- Update `README.md` conventions to include the requirement that source files carry file-level, function-level, and inline explanatory comments.
- Update `PRODUCT.md` to record the new `Core` expectation under current capabilities as `Commented Source Expectations` so the repository’s durable product state reflects the rule.
- Only documentation files were modified and no runtime code was added or changed.

### Testing
- Confirmed repository file listing with `rg --files --hidden -g '!.git/**'` to ensure control documents remain present and visible, and the command completed successfully.
- Verified the new README line with `rg -n "Add explanatory comments" README.md` and the search returned the expected match.
- Inspected the updated sections using file previews to ensure the inserted text appears in `AGENTS.md`, `README.md`, and `PRODUCT.md` as intended.
- Note: this repository contains no checked-in test framework yet, so validation was limited to automated repo checks and manual content inspection and these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67a05c5cc832fb376b4c0a85c2a89)